### PR TITLE
remove old expensive cumulative counting

### DIFF
--- a/govtrack/templates/govtrack/country.html
+++ b/govtrack/templates/govtrack/country.html
@@ -71,8 +71,6 @@
         <th></th>
         <th>Declared?</th>
         <th>Population</th>
-        <th>Contribution</th>
-        <th>Cumulative</th>
     </tr>
     {% for area in areas_list %}
     <tr>

--- a/govtrack/templates/govtrack/country.html
+++ b/govtrack/templates/govtrack/country.html
@@ -105,16 +105,12 @@
         <td align='right'>
             {{ area.population | intcomma }}
         </td>
-        <td align='right'>{{ area.show_contribution | intcomma }}</td>
-        <td align='right'>{{ area.cumulative_pop | intcomma }}</td>
     </tr>
     {% endfor %}
     <tr class='total-pop-row'>
         <td>Total population under declaration:</td>
         <td></td>
         <td align='right'>{{ total_declared_population | intcomma }}</td>
-        <td></td>
-        <td align='right'>{{ total_pop_by_contribution | intcomma }}</td>
     </tr>
 </table>
 

--- a/govtrack/views.py
+++ b/govtrack/views.py
@@ -86,18 +86,6 @@ def country(request, country_id, action='view'):
 
     import_declarations = ImportDeclaration.objects.filter(country=country).order_by('date')
 
-    total_pop = 0
-    item_seen = set()
-    for item in records:
-        if item not in item_seen:
-            total_pop += item.contribution()
-            item.show_contribution = item.contribution()
-            item.cumulative_pop += total_pop
-            item_seen.add(item)
-        else:
-            item.cumulative_pop = total_pop
-            item.show_contribution = 0
-
     total_declared_pop = country.current_popcount
 
     return render(request, 'govtrack/country.html', {
@@ -107,7 +95,6 @@ def country(request, country_id, action='view'):
         'areas_list': records,
         'import_declaration_list': import_declarations,
         'total_declared_population': total_declared_pop,
-        'total_pop_by_contribution': total_pop,
         'links': country.links.all(),
         'form': form,
         'linkform': linkform,


### PR DESCRIPTION
my tests have shown that removing the cumulative pop from the country page roughly halves the load time which philip needs to get the rest of the data in.