### PR TITLE
create .gitattributes to help docker eol

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
git clones to windows with crlf line endings by default which gets copied into the linux container and breaks bash scripts